### PR TITLE
add fetch http client

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "got": "^9.6.0",
+    "isomorphic-fetch": "^2.2.1",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/src/lib/HttpClientBuilder.ts
+++ b/src/lib/HttpClientBuilder.ts
@@ -39,6 +39,11 @@ export default class HttpClientBuilder {
     return this
   }
 
+  public useFetch(): HttpClientBuilder {
+    this.configuration.setRestClient(null, RestClient.FETCH)
+    return this
+  }
+
   public useInterceptors (interceptors: HttpClientInterceptors): HttpClientBuilder {
     this.configuration.setInterceptors(interceptors)
     return this

--- a/src/lib/HttpClientConfiguration.ts
+++ b/src/lib/HttpClientConfiguration.ts
@@ -42,4 +42,8 @@ export default class HttpClientConfiguration {
   public isGot (): boolean {
     return this.restClientType === RestClient.GOT
   }
+
+  public isFetch (): boolean {
+    return this.restClientType === RestClient.FETCH
+  }
 }

--- a/src/lib/HttpClientResponse.ts
+++ b/src/lib/HttpClientResponse.ts
@@ -1,6 +1,7 @@
 import HttpClientConfiguration from './HttpClientConfiguration'
 import AxiosService from './services/AxiosService'
 import RequestService from './services/RequestService'
+import FetchService from './services/FetchService'
 import GotService from './services/GotService'
 import HttpMethod from './constants/HttpMethod'
 
@@ -76,6 +77,10 @@ export default class HttpClientResponse {
           .create(this.configuration.client)
           .makeRequest(request)
 
+        responseBody = JSON.parse(originalResponse.body)
+      } else {
+        originalResponse = await FetchService
+          .makeRequest(request)
         responseBody = JSON.parse(originalResponse.body)
       }
 

--- a/src/lib/constants/RestClient.ts
+++ b/src/lib/constants/RestClient.ts
@@ -1,7 +1,8 @@
 enum RestClient {
   AXIOS = 'axios',
   REQUEST = 'request',
-  GOT = 'got'
+  GOT = 'got',
+  FETCH = 'fetch'
 }
 
 export default RestClient

--- a/src/lib/services/FetchService.ts
+++ b/src/lib/services/FetchService.ts
@@ -1,0 +1,38 @@
+require('isomorphic-fetch')
+
+import RequestSchema from '../schemas/RequestSchema'
+import ErrorSchema from '../schemas/ErrorSchema'
+
+export default class FetchService {
+  public static makeRequest(schema: RequestSchema): Promise<any> {
+    return new Promise((resolve, reject): void => {
+      fetch(new URL(schema.paths + this.paramsToQueryString(schema.params), schema.baseUrl).toString(), {
+        body: schema.payload,
+        headers: schema.headers,
+        method: schema.method,
+      })
+      .then((response: Response) => {
+        response.text().then((body: string) => {
+          if (response.ok) {
+            resolve({
+              body,
+              headers: response.headers,
+              status: response.status,
+              statusText: response.statusText,
+            })
+          } else {
+            reject(ErrorSchema.of(body, response.status))
+          }
+        })
+      })
+      .catch((error: Error) => ErrorSchema.of(error, 0))
+    })
+  }
+
+  private static paramsToQueryString(params: any): string {
+    if (!params) {
+      return ''
+    }
+    return '?' + Object.keys(params).map((param: string) => `${param}=${params[param]}`).join('&')
+  }
+}

--- a/test/HttpClientResponse.spec.ts
+++ b/test/HttpClientResponse.spec.ts
@@ -169,7 +169,7 @@ describe('HttpClientResponse', () => {
     expect(response.return.name).toEqual('Bruno Mayer')
   })
 
-  it('should return when using request service', async () => {
+  it('should return when using got service', async () => {
     const response = await HttpClientBuilder.create('http://api.github.com')
       .useGot(got)
       .client()
@@ -179,4 +179,26 @@ describe('HttpClientResponse', () => {
 
     expect(response.return.name).toEqual('Bruno Mayer')
   })
+})
+
+it('should return when using request service', async () => {
+  const response = await HttpClientBuilder.create('http://api.github.com')
+    .useRequest(request)
+    .client()
+    .path('users', '200')
+    .get()
+    .getResponse<any>()
+
+  expect(response.return.name).toEqual('Bruno Mayer')
+})
+
+it('should return when using fetch service', async () => {
+  const response = await HttpClientBuilder.create('http://api.github.com')
+    .useFetch()
+    .client()
+    .path('users', '200')
+    .get()
+    .getResponse<any>()
+
+  expect(response.return.name).toEqual('Bruno Mayer')
 })


### PR DESCRIPTION
Add a fetch implementation.

fetch is natively supported in modern browsers, so in theory this dependency (isomorphic fetch) could be dropped entirely when building for modern browsers.

I also did this to try and allow for having the other libraries as optional plugins as it seems odd to have multiple competing libraries as dependencies.